### PR TITLE
docs: clarify API contract source

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ Minimalist mobile-first SPA built with Vite + React + TypeScript + TailwindCSS, 
 
 ## API
 
-- API contract is documented in `api-for-web.json` (versioned, REST).
+- Developers can obtain the API contract from the `pesenin-web-api` apps.
 - Auth: JWT via `Authorization: Bearer <token>`.
 - Key endpoints used:
   - Auth: `/api/v1/auth/login`, `/api/v1/auth/logout`, `/api/v1/auth/profile`


### PR DESCRIPTION
## Summary
- update README to reference pesenin-web-api apps as the source for the API contract

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run lint` *(fails: eslint reported 23 errors, 2 warnings)*

------
https://chatgpt.com/codex/tasks/task_e_68a2abb032fc8323a6d8cfd7f1580efa